### PR TITLE
[Feature] pageselector, 마이페이지, 스크랩 기사 보기 페이지, 원본 뉴스 보기 및 필요 컴포넌트 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import "../global.css";
-import { SplashScreen, Stack, useRouter, useSegments } from "expo-router";
+import { SplashScreen, Stack, useRouter, useSegments, usePathname } from "expo-router";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { View } from "react-native";
@@ -9,6 +9,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import ToastContainer from "@/components/ui/toast";
 import { clearExpiredTokens, getToken } from "@/lib/utils/token";
 import { SITEMAP } from "@/data/sitemap";
+import PageSelector from "@/components/ui/page-selector";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -44,10 +45,12 @@ function AuthMiddleware() {
 }
 
 export default function RootLayout() {
-  const [fontsLoaded] = useFonts({ NotoSansKR: require("@/assets/fonts/NotoSansKR.ttf") });
+  const [fontsLoaded] = useFonts({ NotoSansKR: require("@/assets/fonts/NotoSansKR.ttf"), NotoSansKR_Bold : require("@/assets/fonts/NotoSansKR-Bold.ttf") });
   useEffect(() => {
     if (fontsLoaded) SplashScreen.hideAsync();
   }, [fontsLoaded]);
+
+  const pathname = usePathname();
 
   if (!fontsLoaded) return <View className="flex-1 bg-background" />;
 
@@ -56,6 +59,7 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <StatusBar style="light" backgroundColor="#171717" />
         <AuthMiddleware />
+        {["/", "/highlight", "/my-page"].includes(pathname) && <PageSelector />}
         <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: "#171717" } }}>
           <Stack.Screen name="index" options={{ animation: "slide_from_bottom" }} />
           <Stack.Screen name="highlight" />
@@ -63,6 +67,8 @@ export default function RootLayout() {
           <Stack.Screen name="sign-in" />
           <Stack.Screen name="set-nickname" />
           <Stack.Screen name="set-preferences" />
+          <Stack.Screen name="my-page" />
+          <Stack.Screen name="scrap-list" />
         </Stack>
         <ToastContainer />
       </SafeAreaProvider>

--- a/app/my-page.tsx
+++ b/app/my-page.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ImageBackground,
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useRouter } from "expo-router";
+import {
+  FontAwesome,
+  MaterialIcons,
+  MaterialCommunityIcons,
+} from "@expo/vector-icons";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import type { MyPageDto, SectionWithBehaviorDto } from "@/types/dto";
+import { sectionLabels, SectionType } from "@/types/types";
+import { getMyPageStats } from "@/lib/apis/apis";
+import Hexagon from "@/components/ui/hexagon";
+import WordCloudRN from "@/components/features/my-page/word-cloud";
+
+export default function MyPageScreen() {
+  const router = useRouter();
+  const [data, setData] = useState<MyPageDto | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const res = await getMyPageStats();
+      if (res.error) {
+        Alert.alert("오류", res.error.message);
+      } else {
+        setData(res.data);
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const sectionsMap = useMemo(() => {
+    const acc = {} as Record<SectionType, SectionWithBehaviorDto>;
+    (data?.sectionStats ?? []).forEach((s) => (acc[s.sectionName] = s));
+    return acc;
+  }, [data]);
+
+  const preferenceRadii = sectionLabels.map(
+    (label) => (sectionsMap[label]?.preference ?? 1) * 30
+  );
+  const behaviorRadii = sectionLabels.map(
+    (label) => (sectionsMap[label]?.behaviorScore ?? 1) * 30
+  );
+
+  return (
+    <SafeAreaView className="flex-1 text-[#FAFAFA] bg-[#1F1F1F]">
+      <View className="pt-16 px-7 pb-8">
+        <View className="flex-row items-center mb-2">
+          {loading ? (
+            <Text className="text-[#FAFAFA] typography-sub-title-bold mr-1">
+              사용자
+              <Text className="text-[#FAFAFA] typography-body1"> 님</Text>
+            </Text>
+          ) : (
+            <Text className="text-[#FAFAFA] typography-sub-title-bold mr-1">
+              {data?.user.nickname}
+              <Text className="text-[#FAFAFA] typography-body1"> 님</Text>
+            </Text>
+          )}
+          <Pressable onPress={() => router.push("/set-nickname")} hitSlop={8}>
+            <MaterialCommunityIcons name="pencil" size={20} color="#FAFAFA" />
+          </Pressable>
+        </View>
+
+        <Pressable
+          className="mb-4 flex-row items-center justify-between rounded-xl bg-[#2E2E2E] p-3"
+          onPress={() => router.push("/scrap-list")}
+        >
+          <View className="flex-row items-center">
+            <FontAwesome name="bookmark" size={18} color="#FAFAFA" />
+            <Text className="text-[#FAFAFA] ml-3 typography-body1">
+              스크랩 목록
+            </Text>
+          </View>
+          <MaterialIcons name="chevron-right" size={20} color="#FAFAFA" />
+        </Pressable>
+
+        <View className="mb-4">
+          <Text className="mb-2 typography-body2 text-[#FAFAFA]">
+            내가 읽은 뉴스
+          </Text>
+
+          <View className="items-center overflow-hidden rounded-xl bg-[#2E2E2E]">
+            <View className="p-4">
+              <Hexagon
+                hexagons={[
+                  {
+                    radii: preferenceRadii,
+                    fill: "#FF880060",
+                    stroke: "#FF8800",
+                  },
+                  {
+                    radii: behaviorRadii,
+                    fill: "#AEFF8860",
+                    stroke: "#AEFF88",
+                  },
+                ]}
+                width={220}
+                height={220}
+              />
+            </View>
+
+            <View className="-mt-2 mb-3 flex-row">
+              <View className="flex-row items-center">
+                <FontAwesome name="square" size={12} color="#AEFF88" />
+                <Text className="ml-2 typography-caption3 text-[#FAFAFA]">
+                  읽은 뉴스
+                </Text>
+              </View>
+
+              <View className="w-5" />
+
+              <View className="flex-row items-center">
+                <FontAwesome name="square" size={12} color="#FF8800" />
+                <Text className="ml-2 typography-caption3 text-[#FAFAFA]">
+                  선호도
+                </Text>
+              </View>
+            </View>
+
+            <Pressable
+              className="w-full flex-row items-center justify-between border-t border-[#5D5D5D] px-3 py-3"
+              onPress={() => router.push("/set-preferences")}
+            >
+              <Text className="typography-body2 text-[#FAFAFA]">
+                관심 카테고리 수정
+              </Text>
+              <MaterialIcons name="chevron-right" size={20} color="#FAFAFA" />
+            </Pressable>
+          </View>
+        </View>
+
+        <View className="mb-8">
+          <Text className="mb-2 typography-body2 text-[#FAFAFA]">
+            자주 접한 키워드
+          </Text>
+
+          <View className="h-52 overflow-hidden rounded-xl bg-[#2E2E2E]">
+            {loading ? (
+              <View className="flex-1 items-center justify-center">
+                <ActivityIndicator />
+              </View>
+            ) : data && data.keywordStats.length > 10 ? (
+              <WordCloudRN items={data.keywordStats} height={188} />
+            ) : (
+              <View className="flex-1">
+                <ImageBackground
+                  source={require("@/assets/images/keyword-bg.png")}
+                  style={{
+                    flex: 1,
+                    justifyContent: "center",
+                    alignItems: "center",
+                    paddingHorizontal: 16,
+                  }}
+                  resizeMode="cover"
+                  blurRadius={8}
+                >
+                  <Text className="text-center leading-5 text-[#FAFAFA]">
+                    키워드 분석 준비 중입니다.{"\n"}더 많은 뉴스 시청 기록이
+                    필요해요 !
+                  </Text>
+                </ImageBackground>
+              </View>
+            )}
+          </View>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/app/scrap-list.tsx
+++ b/app/scrap-list.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { MaterialIcons, FontAwesome } from "@expo/vector-icons";
+
+import type { NewsDto } from "@/types/dto";
+import { getScrapedArticles } from "@/lib/apis/apis";
+import ArticleCard from "@/components/features/my-page/article-card";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function ScrapsPage() {
+  const router = useRouter();
+  const [items, setItems] = useState<NewsDto[]>([]);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [hasNext, setHasNext] = useState(true);
+
+  const fetchMore = useCallback(async () => {
+    if (loading || !hasNext) return;
+    setLoading(true);
+    const res = await getScrapedArticles(8, cursor);
+    if (res.error) {
+      setLoading(false);
+      return;
+    }
+    const { data, pagination } = res;
+    if (data) {
+      setItems((prev) => [...prev, ...data]);
+      setCursor(pagination?.nextCursor ?? undefined);
+      setHasNext(pagination?.hasNext ?? false);
+    }
+    setLoading(false);
+  }, [cursor, hasNext, loading]);
+
+  useEffect(() => {
+    fetchMore();
+  }, []);
+
+  const renderItem = ({ item, index }: { item: NewsDto; index: number }) => (
+    <ArticleCard article={item} index={index} />
+  );
+
+  return (
+    <SafeAreaView className="flex-1 bg-[#1F1F1F]">
+      <View className="flex-row items-center justify-center px-4 h-20 relative">
+        <Pressable
+          onPress={() => router.back()}
+          className="absolute left-4"
+          hitSlop={30}
+        >
+          <MaterialIcons name="chevron-left" size={30} color="#FAFAFA" />
+        </Pressable>
+        <Text className="typography-small-title text-[#FAFAFA]">
+          스크랩 목록
+        </Text>
+      </View>
+
+      {items.length === 0 && !loading ? (
+        <View className="flex-1 items-center justify-center">
+          <FontAwesome name="bookmark" size={32} color="#666" />
+          <Text className="mt-4 text-center text-sm text-[#FAFAFA]">
+            아직 스크랩한 기사가 없어요.{"\n"}관심 기사를 스크랩 해보세요!
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={(item) => String(item.id)}
+          numColumns={2}
+          columnWrapperStyle={{ gap: 12 }}
+          contentContainerStyle={{ padding: 16, gap: 12 }}
+          onEndReached={fetchMore}
+          onEndReachedThreshold={0.5}
+          ListFooterComponent={
+            loading ? (
+              <View className="py-6 items-center justify-center">
+                <ActivityIndicator color="#FAFAFA" />
+              </View>
+            ) : !hasNext && items.length > 0 ? (
+              <Text className="py-6 text-center typography-caption3 text-[#FAFAFA]">
+                마지막 기사입니다.
+              </Text>
+            ) : null
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}

--- a/components/features/my-page/article-card.tsx
+++ b/components/features/my-page/article-card.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, Pressable, ImageBackground } from 'react-native';
+import { useRouter } from 'expo-router';
+import { BlurView } from 'expo-blur';
+import { LinearGradient } from 'expo-linear-gradient';
+import type { NewsDto } from '@/types/dto';
+
+type ArticleCardProps = {
+  article: NewsDto;
+  index: number;
+};
+
+const ArticleCard: React.FC<ArticleCardProps> = ({ article, index }) => {
+  const router = useRouter();
+
+  return (
+    <Pressable
+      onPress={() => router.push(`/scrap?index=${index}`)}
+      className="relative overflow-hidden rounded-xl flex-1"
+      style={{ aspectRatio: 10 / 16 }}
+    >
+      <ImageBackground
+        source={{ uri: article.thumbnailUrl }}
+        className="w-full h-full"
+        resizeMode="cover"
+      >
+        <View className="absolute inset-0">
+          <BlurView intensity={50} tint="dark" style={{ flex: 1 }}>
+            <LinearGradient
+              colors={['rgba(0,0,0,0.8)', 'transparent']}
+              start={{ x: 0.5, y: 1 }}
+              end={{ x: 0.5, y: 0.6 }}
+              style={{ flex: 1 }}
+            />
+          </BlurView>
+        </View>
+
+        <View className="absolute bottom-0 left-0 right-0 p-3">
+          <Text className="typography-caption2 text-[#FAFAFA]" numberOfLines={3}>
+            {article.title}
+          </Text>
+        </View>
+      </ImageBackground>
+    </Pressable>
+  );
+};
+
+export default ArticleCard;

--- a/components/features/my-page/word-cloud.tsx
+++ b/components/features/my-page/word-cloud.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from "react";
+import { Dimensions, View } from "react-native";
+import WordCloud from "rn-wordcloud";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+
+type Item = { keyword: string; count: number };
+
+type CloudProps = {
+  items: Item[];
+  height?: number;
+  colors?: string[];
+  minFont?: number;
+  maxFont?: number;
+  fontFamily?: string;
+  onWordPress?: (w: { text: string; value: number; color?: string }) => void;
+};
+
+const WordCloudRN: React.FC<CloudProps> = ({
+  items = [],
+  height = 208,
+  colors = ["#ff904b", "#ffb764", "#ffd13c", "#ffeec3", "#1ab6b2"],
+  minFont = 8,
+  maxFont = 40,
+  fontFamily = "NotoSansKR_Bold",
+  onWordPress,
+}) => {
+  const words = useMemo(() => {
+    const top = [...(items ?? [])]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20);
+
+    return top.map((k, i) => ({
+      text: k.keyword,
+      value: k.count,
+      color: colors[i % colors.length],
+      fontFamily,
+    }));
+  }, [items, colors, fontFamily]);
+
+  return (
+    <View style={{ width: "100%", height }}>
+      <WordCloud
+        options={{
+          words,
+          verticalEnabled: false,
+          minFont,
+          maxFont,
+          fontOffset: 1,
+          width: SCREEN_WIDTH - 32,
+          height,
+          fontFamily,
+        }}
+        onWordPress={onWordPress}
+      />
+    </View>
+  );
+};
+
+export default WordCloudRN;

--- a/components/features/news/news-abstract-view.tsx
+++ b/components/features/news/news-abstract-view.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/apis/apis";
 import { NewsDto } from "@/types/dto";
 import { MaterialIcons } from "@expo/vector-icons";
+import NewsProvider from "./news-provider";
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
 
@@ -125,7 +126,7 @@ const NewsAbstractView = (news: NewsAbstractViewProps) => {
           <Text className="typography-body2 line-clamp-3 mb-4">{news.oneLineSummary}</Text>
 
           <View className="absolute bottom-10 right-8">
-            <Text className="typography-caption">뉴스 제공사</Text>
+            <NewsProvider providers={news.providers}/>
           </View>
         </View>
       </SafeAreaView>

--- a/components/features/news/news-provider.tsx
+++ b/components/features/news/news-provider.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  Modal,
+  TouchableOpacity,
+  Linking,
+  Image,
+} from "react-native";
+import type { NewsProviderDto } from "@/types/dto";
+import { MaterialIcons } from "@expo/vector-icons";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+type NewsProviderProps = {
+  providers: NewsProviderDto[];
+  title?: string;
+};
+
+const ITEM_HEIGHT = 60;
+
+const NewsProvider: React.FC<NewsProviderProps> = ({ providers, title }) => {
+  const [open, setOpen] = useState(false);
+
+  const uniqueProviders = providers.filter(
+    (provider, index, self) =>
+      index === self.findIndex((p) => p.id === provider.id)
+  );
+
+  return (
+    <>
+      <Pressable onPress={() => setOpen(true)}>
+        <View className="flex-row">
+          {uniqueProviders.slice(0, 3).map((provider) => (
+            <View
+              key={provider.id}
+              className="w-6 h-6 rounded-full overflow-hidden -mr-2 bg-[#fafafa]"
+            >
+              <Image
+                source={{ uri: provider.logoUrl }}
+                className="w-full h-full"
+                resizeMode="cover"
+              />
+            </View>
+          ))}
+        </View>
+      </Pressable>
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable
+          onPress={() => setOpen(false)}
+          className="flex-1 bg-[#17171742] justify-end"
+        >
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            className="bg-[#2b2b2b] rounded-t-2xl p-4 w-full"
+          >
+            <View className="flex-row justify-between items-center mb-3">
+              <View className="flex-row items-center pl-2">
+                <Ionicons
+                  name="sparkles-sharp"
+                  size={12}
+                  color="#FAFAFA"
+                  style={{ marginRight: 6 }}
+                />
+                <Text className="text-white typography-caption3">
+                  아래 뉴스들을 종합했어요!
+                </Text>
+              </View>
+              <Pressable onPress={() => setOpen(false)}>
+                <MaterialIcons name="close" size={24} color="#FAFAFA" />
+              </Pressable>
+            </View>
+
+            <ScrollView
+              style={{
+                height:
+                  uniqueProviders.length > 4
+                    ? ITEM_HEIGHT * 4
+                    : ITEM_HEIGHT * uniqueProviders.length,
+              }}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={{
+                paddingBottom: 12,
+                paddingHorizontal: 12,
+              }}
+            >
+              {uniqueProviders.map((provider, idx) => (
+                <TouchableOpacity
+                  key={provider.id}
+                  onPress={() => Linking.openURL(provider.newsUrl)}
+                  activeOpacity={0.7}
+                  className="flex-row items-center mb-5"
+                  style={{ height: ITEM_HEIGHT - 12 }}
+                >
+                  <View className="w-12 h-12 rounded-full overflow-hidden mr-3 bg-[#fafafa]">
+                    <Image
+                      source={{ uri: provider.logoUrl }}
+                      className="w-full h-full"
+                      resizeMode="cover"
+                    />
+                  </View>
+                  <View className="flex-1 ml-1">
+                    <Text
+                      className="text-[#ffffff] typography-caption2 mb-[-7]"
+                      numberOfLines={1}
+                    >
+                      기사 원제목
+                    </Text>
+                    <Text className="text-[#9b9a9a] typography-caption3">
+                      {provider.friendlyName}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+};
+
+export default NewsProvider;

--- a/components/ui/page-selector.tsx
+++ b/components/ui/page-selector.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Pressable,
+  Animated,
+  Easing,
+  StyleSheet,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { useRouter, usePathname } from "expo-router";
+import { useHighlightStore } from "@/lib/stores/highlight";
+
+type Page = { href: string; label: string };
+
+const pages: Page[] = [
+  { href: "/", label: "Some's up" },
+  { href: "/highlight", label: "5분 뉴스" },
+  { href: "/my-page", label: "마이페이지" },
+];
+
+export default function PageSelector({ style }: { style?: any }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isVisited = useHighlightStore((s) => s.isVisited);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  const currentPage = useMemo(
+    () => pages.find((p) => p.href === pathname) ?? pages[0],
+    [pathname]
+  );
+  const otherPages = useMemo(
+    () => pages.filter((p) => p.href !== currentPage.href),
+    [currentPage.href]
+  );
+
+  useEffect(() => setMounted(true), []);
+  const shouldShowIndicator = mounted && !isVisited();
+
+  const progress = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    if (isOpen) {
+      setIsVisible(true);
+      Animated.timing(progress, {
+        toValue: 1,
+        duration: 150,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(progress, {
+        toValue: 0,
+        duration: 150,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start(({ finished }) => finished && setIsVisible(false));
+    }
+  }, [isOpen, progress]);
+
+  const scale = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.98, 1],
+  });
+  const translateY = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-8, 0],
+  });
+  const opacity = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 1],
+  });
+
+  const handleClose = () => setIsOpen(false);
+  const handleNavigate = (href: string) => {
+    setIsOpen(false);
+    router.push(href as any);
+  };
+
+  return (
+    <>
+      {isVisible && (
+        <Pressable
+          onPress={handleClose}
+          style={StyleSheet.absoluteFill}
+          className="z-40 bg-black/50"
+        />
+      )}
+
+      <View
+        className="absolute top-16 z-50 w-full"
+        style={[{ alignItems: "center" }, style]}
+        pointerEvents="box-none"
+      >
+        <View style={{ position: "relative" }}>
+          <TouchableOpacity
+            onPress={() => setIsOpen((o) => !o)}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: isOpen }}
+            activeOpacity={0.8}
+            className="relative flex-row items-center"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            {!isOpen && shouldShowIndicator && (
+              <FontAwesome
+                name="circle"
+                size={8}
+                color="#FF3F62"
+                style={{
+                  position: "absolute",
+                  left: -14,
+                  top: "50%",
+                  marginTop: -4,
+                }}
+              />
+            )}
+            <Text
+              className="typography-small-title"
+              style={{ color: "#FAFAFA" }}
+            >
+              {currentPage.label}
+            </Text>
+            <View
+              style={{
+                position: "absolute",
+                right: -24,
+                top: "50%",
+                transform: [{ translateY: -11 }],
+              }}
+            >
+              <MaterialIcons
+                name={isOpen ? "keyboard-arrow-up" : "keyboard-arrow-down"}
+                size={22}
+                color="#FAFAFA"
+              />
+            </View>
+          </TouchableOpacity>
+          {isVisible && (
+            <Animated.View
+              style={{
+                position: "absolute",
+                top: 36,
+                left: 0,
+                right: 0,
+                alignItems: "center",
+                transform: [{ translateY }, { scale }],
+                opacity,
+              }}
+              pointerEvents={isOpen ? "auto" : "none"}
+            >
+              <View style={{ alignItems: "center" }}>
+                {otherPages.map(({ href, label }) => (
+                  <TouchableOpacity
+                    key={href}
+                    onPress={() => handleNavigate(href)}
+                    activeOpacity={0.75}
+                    style={{
+                      paddingVertical: 6,
+                      marginVertical: 6,
+                      minWidth: 140,
+                    }}
+                  >
+                    <View
+                      style={{ position: "relative", alignItems: "center" }}
+                    >
+                      {label === "5분 뉴스" && shouldShowIndicator && (
+                        <FontAwesome
+                          name="circle"
+                          size={8}
+                          color="#FF3F62"
+                          style={{
+                            position: "absolute",
+                            left: 26,
+                            top: "50%",
+                            marginTop: -4,
+                          }}
+                        />
+                      )}
+                      <Text
+                        className="typography-small-title"
+                        style={{ color: "#FAFAFA" }}
+                      >
+                        {label}
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </Animated.View>
+          )}
+        </View>
+      </View>
+    </>
+  );
+}

--- a/data/sitemap.ts
+++ b/data/sitemap.ts
@@ -7,7 +7,7 @@ export const SITEMAP = {
   HOME: "/",
   HIGHLIGHT: "/highlight",
   MY_PAGE: "/my-page",
-  MY_PAGE_SCRAP: "/my-page/scrap",
+  MY_PAGE_SCRAP: "/scrap-list",
   SCRAP: "/scrap",
   SET_NICKNAME: "/set-nickname",
   SET_PREFERENCES: "/set-preferences",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-native-svg": "15.11.2",
         "react-native-uuid": "^2.0.3",
         "react-native-web": "^0.20.0",
+        "rn-wordcloud": "^1.0.6",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.8"
       },
@@ -8516,6 +8517,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/rn-wordcloud": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/rn-wordcloud/-/rn-wordcloud-1.0.6.tgz",
+      "integrity": "sha512-9rOj20jFm3TKZaQ0vhW8N78h2gTXGu3mRbRpAdWp3DtclKubghWavawNc/WO2L9uZ9ZcBeYupV5v1ZyszBNFgg==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native-svg": "15.11.2",
     "react-native-uuid": "^2.0.3",
     "react-native-web": "^0.20.0",
+    "rn-wordcloud": "^1.0.6",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.8"
   },

--- a/types/rn-wordcloud.d.ts
+++ b/types/rn-wordcloud.d.ts
@@ -1,0 +1,55 @@
+// src/types/rn-wordcloud.d.ts
+declare module 'rn-wordcloud' {
+  import { ComponentType } from 'react';
+  import { ViewStyle } from 'react-native';
+
+  /** A single word item used by rn-wordcloud */
+  export interface WordItem {
+    /** Display text */
+    text: string;
+    /** Weight / importance */
+    value: number;
+    /** Optional per-word font family override */
+    fontFamily?: string;
+    /** Optional sentiment flag (supported by lib) */
+    sentiment?: string | number | boolean;
+    /** Optional color (supported by examples) */
+    color?: string;
+  }
+
+  /** Options object passed to the component */
+  export interface WordCloudOptions {
+    /** Words data (required) */
+    words: WordItem[];
+    /** Enable vertical alignment (default: true) */
+    verticalEnabled?: boolean;
+    /** Minimum font size (default: 10) */
+    minFont?: number;
+    /** Maximum font size (default: 50) */
+    maxFont?: number;
+    /** Font offset for extra tuning (default: 1) */
+    fontOffset?: number;
+    /** Container width (required) */
+    width: number;
+    /** Container height (required) */
+    height: number;
+    /** Default font family for all words */
+    fontFamily?: string;
+  }
+
+  export interface WordCloudProps {
+    /** Rendering & layout options */
+    options: WordCloudOptions;
+    /** Optional style for the outer View */
+    style?: ViewStyle;
+    /**
+     * Fired when a word is pressed.
+     * The library’s README documents `text` and `value`,
+     * but we pass through the whole item for convenience.
+     */
+    onWordPress?: (word: WordItem) => void;
+  }
+
+  const WordCloud: ComponentType<WordCloudProps>;
+  export default WordCloud;
+}


### PR DESCRIPTION
## 📝 작업 내용

- pageselector 구현
- 스크랩 기사 보기 페이지 구현
- 마이페이지 구현
- 원본 뉴스 보기 컴포넌트 구현
- 구현에 필요한 기타 컴포넌트 동일하게 구현

<br>

## 💬 리뷰 요구사항

> - 원본 뉴스 보기 애니메이션은 다른 부분 고치면서 함께 추가하겠습니다! 조금 시간이 걸릴 거 같아 일단 다른 부분부터 구현했습니다.
> - pageselector을 구현했는데, 페이지 자체에 넣으면 클릭이 어떤 식으로 해도 안되어서 최상위 단계에 배치했습니다. 그러나 여기서 문제가 생기는 게, 기사 자세히 보기를 하거나 토스트가 떠도 그 위에 pageselector가 떠서, 이 부분은 어떻게 해야 할 지 모르겠습니다.
> - 추가로 빌드를 완전히 하지 않아서인지는 모르겠으나, 뉴스 기사들을 계속해서 내리다 보면, 앱 속도가 현저하게 떨어지는 부분이 생깁니다.